### PR TITLE
Add docstrings to API

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -5,5 +5,6 @@ python-dotenv
 python-multipart
 pymongo[srv]
 requests
+starlette
 uvicorn
 wfcommons

--- a/api/src/metrics/graph.py
+++ b/api/src/metrics/graph.py
@@ -2,12 +2,28 @@ from collections import defaultdict
 
 
 class Graph:
+    """Graph data structure represented as an adjacency list using a dictionary."""
+
     def __init__(self):
+        """Initialize the graph."""
         self.adj_dict = defaultdict(list)
 
     def add_node(self, node):
+        """
+        Add a node to the graph.
+
+        Args:
+            node (any): The node to add to the graph
+        """
         self.adj_dict[node] = []
 
     def add_edge(self, u, v):
+        """
+        Add a directed edge to the graph. Prevents adding duplicate directed edges.
+
+        Args:
+            u (any): The node to start from
+            v (any): The node to point to
+        """
         if v not in self.adj_dict[u]:
             self.adj_dict[u].append(v)

--- a/api/src/metrics/router.py
+++ b/api/src/metrics/router.py
@@ -8,6 +8,9 @@ router = APIRouter()
 
 @router.get('/', response_model=ApiResponse)
 async def get_all_metrics() -> dict[str, str | list[dict]]:
+    """
+    Get all the metrics from the collection.
+    """
     metrics = serialize_metrics(metrics_collection.find())
     return {
         'detail': ('Metrics retrieved.'
@@ -19,6 +22,11 @@ async def get_all_metrics() -> dict[str, str | list[dict]]:
 
 @router.get('/{id}', response_model=ApiResponse)
 async def get_metric(id: str) -> dict[str, dict]:
+    """
+    Get a metric from the collection.
+
+    - **id**: The id of the metric, usually stored in the collection as a filename that ends in .json
+    """
     metric = serialize_metric(metrics_collection.find_one({'_id': id}))
     return {
         'detail': ('Metric retrieved.'

--- a/api/src/metrics/serializer.py
+++ b/api/src/metrics/serializer.py
@@ -1,4 +1,12 @@
 def serialize_metric(metric: dict) -> dict | None:
+    """
+    Serialize a single metric.
+
+    Args:
+        metric: The metric to serialize
+
+    Returns: The serialized metric or None if the metric passed in is None
+    """
     return {
         'id': metric.get('_id'),
         'githubRepo': metric.get('_githubRepo'),
@@ -14,4 +22,12 @@ def serialize_metric(metric: dict) -> dict | None:
 
 
 def serialize_metrics(metrics: list[dict]) -> list[dict]:
+    """
+    Serialize a list of metrics.
+
+    Args:
+        metrics: The list of metrics to serialize
+
+    Returns: The serialized list of metrics
+    """
     return [serialize_metric(metrics) for metrics in metrics if metrics]

--- a/api/src/metrics/service.py
+++ b/api/src/metrics/service.py
@@ -3,11 +3,27 @@ from src.metrics.graph import Graph
 
 
 def generate_metrics(wf_instance: dict) -> dict:
+    """
+    Generate the num_tasks, num_files, total_bytes_read, total_bytes_written, depth, min_width, max_width metrics.
+
+    Args:
+        wf_instance: The WfInstance to generate metrics on
+
+    Returns: The metrics generated using the list and graph data structures
+    """
     tasks = wf_instance['workflow']['tasks']
     return _generate_list_metrics(tasks) | _generate_graph_metrics(tasks)
 
 
 def _generate_list_metrics(tasks: list[dict]) -> dict:
+    """
+    Generate the num_tasks, num_files, total_bytes_read, total_bytes_written metrics.
+
+    Args:
+        tasks: The list of tasks of an WfInstance to generate metrics on
+
+    Returns: The metrics generated using the list data structure
+    """
     files, total_bytes_read, total_bytes_written, work = set(), 0, 0, 0
 
     for task in tasks:
@@ -27,6 +43,14 @@ def _generate_list_metrics(tasks: list[dict]) -> dict:
 
 
 def _generate_graph_metrics(tasks: list[dict]) -> dict:
+    """
+    Generate the depth, min_width, max_width metrics.
+
+    Args:
+        tasks: The list of tasks of an WfInstance to generate metrics on
+
+    Returns: The metrics generated using the graph data structure
+    """
     # Build graph of tasks and files
     graph = Graph()
     for index, task in enumerate(tasks):

--- a/api/src/wfinstances/exceptions.py
+++ b/api/src/wfinstances/exceptions.py
@@ -3,11 +3,24 @@ from starlette.responses import JSONResponse
 
 
 class InvalidWfInstanceException(Exception):
+    """Exception to be raised when an WfInstance does not match the expected schema."""
+
     def __init__(self, detail: str):
+        """Raise the exception with a detail message."""
         self.detail = detail
 
 
 def invalid_wf_instance_exception_handler(request: Request, exc: InvalidWfInstanceException) -> Response:
+    """
+    Exception handler used with FastAPI (in main.py) to catch a raised InvalidWfInstanceException and return
+    the 422 status code with the detail message.
+
+    Args:
+        request: Required request parameter that is handled by FastAPI
+        exc: Required exception parameter to catch the InvalidWfInstanceException exception that is handled by FastAPI
+
+    Returns: The 422 status code with the detail message
+    """
     return JSONResponse(
         status_code=422,
         content={'detail': exc.detail}

--- a/api/src/wfinstances/router.py
+++ b/api/src/wfinstances/router.py
@@ -10,6 +10,11 @@ router = APIRouter()
 
 @router.post('/', response_model=ApiResponse)
 async def get_wf_instances(ids: list[str]) -> dict[str, list[dict]]:
+    """
+    Get a list of WfInstances.
+
+    - **Request body**: List of ids to retrieve, usually stored in the collection as a filename that ends in .json
+    """
     wf_instances = serialize_wf_instances(wf_instance_collection.find({'_id': {'$in': ids}}))
     return {
         'detail': ('WfInstances retrieved.'
@@ -21,6 +26,11 @@ async def get_wf_instances(ids: list[str]) -> dict[str, list[dict]]:
 
 @router.delete('/', response_model=ApiResponse)
 async def delete_wf_instances(ids: list[str]) -> dict[str, str]:
+    """
+    Delete WfInstances and their associated metrics.
+
+    - **Request body**: List of ids to delete, usually stored in the collection as a filename that ends in .json
+    """
     wf_instance_collection.delete({'_id': {'$in': ids}})
     metrics_collection.delete({'_id': {'$in': ids}})
     return {
@@ -31,6 +41,11 @@ async def delete_wf_instances(ids: list[str]) -> dict[str, str]:
 
 @router.delete('/{id}', response_model=ApiResponse)
 async def delete_wf_instance(id: str) -> dict[str, str]:
+    """
+    Delete a single WfInstance and its associated metrics.
+
+    - **id**: The id to delete, usually stored in the collection as a filename that ends in .json
+    """
     wf_instance_collection.delete_one({'_id': id})
     metrics_collection.delete_one({'_id': id})
     return {
@@ -41,6 +56,11 @@ async def delete_wf_instance(id: str) -> dict[str, str]:
 
 @router.get('/{id}', response_model=ApiResponse)
 async def get_wf_instance(id: str) -> dict[str, dict]:
+    """
+    Get a single WfInstance
+
+    - **id**: The id to retrieve, usually stored in the collection as a filename that ends in .json
+    """
     wf_instance = serialize_wf_instance(wf_instance_collection.find_one({'_id': id}))
     return {
         'detail': ('WfInstance retrieved.'
@@ -52,6 +72,12 @@ async def get_wf_instance(id: str) -> dict[str, dict]:
 
 @router.post('/github/{owner}/{repo}', response_model=ApiResponse)
 async def post_wf_instances_github(owner: str, repo: str) -> dict[str, str | list]:
+    """
+    Insert WfInstances and generate their metrics from a GitHub repository into the MongoDB collections.
+
+    - **owner**: The owner of the GitHub repository
+    - **repo**: The name of the GitHub repository
+    """
     valid_wf_instances, invalid_wf_instances = insert_wf_instances_from_github(owner, repo)
     return {
         'detail': ('Some WfInstances were not added, check that they follow the WfFormat.'
@@ -66,6 +92,11 @@ async def post_wf_instances_github(owner: str, repo: str) -> dict[str, str | lis
 
 @router.put('/json', response_model=ApiResponse)
 async def put_wf_instance_json(file: UploadFile) -> dict[str, str]:
+    """
+    Insert a WfInstance and generate their metrics from a JSON file into the MongoDB collections.
+
+    - **Request body**: The JSON file
+    """
     wf_instance = json.loads(file.file.read())
     insert_wf_instance(wf_instance, file.filename)
     return {

--- a/api/src/wfinstances/serializer.py
+++ b/api/src/wfinstances/serializer.py
@@ -1,4 +1,12 @@
 def serialize_wf_instance(wf_instance: dict) -> dict | None:
+    """
+    Serialize a single WfInstance.
+
+    Args:
+        wf_instance: The WfInstance to serialize
+
+    Returns: The serialized WfInstance or None if the WfInstance passed in is None
+    """
     return {
         'name': wf_instance.get('name'),
         'description': wf_instance.get('description', ''),
@@ -11,4 +19,12 @@ def serialize_wf_instance(wf_instance: dict) -> dict | None:
 
 
 def serialize_wf_instances(wf_instances: list[dict]) -> list[dict]:
+    """
+    Serialize a list of WfInstances.
+
+    Args:
+        wf_instances: The list of WfInstances to serialize
+
+    Returns: The serialized list of WfInstances
+    """
     return [serialize_wf_instance(wf_instances) for wf_instances in wf_instances if wf_instances]


### PR DESCRIPTION
Adds the Google format for Python docstrings. 

Note that the `metrics/router.py` and `wfinstances.py/router.py` routers are in a different format so that FastAPI can display the docstrings at `/docs`:
![image](https://github.com/ICS496WfCommons/wfinstances-browser/assets/42422209/7cdbadc6-2261-4de7-bfce-b7d999f70b5c)
![image](https://github.com/ICS496WfCommons/wfinstances-browser/assets/42422209/f2cdf076-1e7c-40c1-b0ab-e45b43795b5c)
![image](https://github.com/ICS496WfCommons/wfinstances-browser/assets/42422209/de5edd8c-702a-4e37-b7d6-cf63c68ae95b)
