### PR TITLE
Completed File Toggle Feature

### DIFF
--- a/ui/src/components/GraphModal.tsx
+++ b/ui/src/components/GraphModal.tsx
@@ -128,7 +128,8 @@ export function GraphModal({
         return graphElementsWithFiles;
     }
 
-    const { isLoading, data: elements, refetch } = useQuery({
+    const { isLoading, refetch } = useQuery({
+        refetchOnWindowFocus: false,
         queryKey: ['id', id],
         queryFn: () => 
             fetch(`http://localhost:8081/wf-instances/${id}`)
@@ -163,7 +164,7 @@ export function GraphModal({
                     />
                 </>
             )}
-            <Group justify="center">
+            <Group justify="center" pt={15}>
                 <Button variant="default" onClick={() => refetch()}>Shuffle Colors</Button>
                 <Button variant="success" onClick={swapElements}>Display Type: {useElementsWithFiles ? "Tasks and Files" : "Tasks Only"}</Button>
             </Group>


### PR DESCRIPTION
Graph Visualization now allows for users to toggle between displaying tasks and files, or just displaying tasks.
<img width="1125" alt="Disp1" src="https://github.com/ICS496WfCommons/wfinstances-browser/assets/97561440/b8d227ba-d067-4cc2-9148-7d72fcbbcb0d">
<img width="1128" alt="Disp2" src="https://github.com/ICS496WfCommons/wfinstances-browser/assets/97561440/1fcd9372-9ac8-4afb-94d7-f024f4288db5">
